### PR TITLE
Add screenshot capture to Ready button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -470,6 +470,9 @@ textarea {
     background: #000;
     color: #fff;
 }
+#ready-btn.captured {
+    background: #48b348;
+}
 .brush-slider {
     -webkit-appearance: none;
     appearance: none;

--- a/js/main.js
+++ b/js/main.js
@@ -2,6 +2,17 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
+function dataURLtoBlob(dataURL) {
+    const [header, data] = dataURL.split(',');
+    const mime = header.match(/:(.*?);/)[1];
+    const binary = atob(data);
+    const array = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+        array[i] = binary.charCodeAt(i);
+    }
+    return new Blob([array], { type: mime });
+}
+
 // --- Application State & Data ---
 const appData = {
     contact: {},
@@ -81,7 +92,12 @@ function setupFormSubmission() {
             `Часть тела: ${space.part}, Размер: ${space.size}${space.details ? ', Детали: ' + space.details : ''}`
         ).join('; \n');
         formData.append('bodySpaces', bodySpacesText || 'Не указано');
-        
+
+        if (appData.tattooIdea.screenshot3D) {
+            const blob = dataURLtoBlob(appData.tattooIdea.screenshot3D);
+            formData.append('screenshot', blob, 'screenshot.png');
+        }
+
         appData.tattooIdea.references.forEach((ref, index) => {
         formData.append('references', ref.file, `reference_${index + 1}.jpg`);
         });
@@ -253,7 +269,11 @@ function init3DScene() {
     scene.background = new THREE.Color(0xf0f0f0);
     camera = new THREE.PerspectiveCamera(45, W / H, 0.1, 1000);
     camera.position.set(0, 1.5, 8);
-    renderer = new THREE.WebGLRenderer({ antialias: true });
+    // Preserve the drawing buffer so screenshots contain the rendered model
+    renderer = new THREE.WebGLRenderer({
+        antialias: true,
+        preserveDrawingBuffer: true
+    });
     renderer.setSize(W, H);
     DOMElements.modelWrapper.appendChild(renderer.domElement);
 
@@ -283,6 +303,16 @@ function init3DScene() {
         controls.enabled = !paintMode;
         uiElements.paintBtn.classList.toggle('active', paintMode);
     };
+
+    // Capture screenshot when the user is satisfied
+    uiElements.readyBtn.addEventListener('click', () => {
+        try {
+            appData.tattooIdea.screenshot3D = renderer.domElement.toDataURL('image/png');
+            uiElements.readyBtn.classList.add('captured');
+        } catch (err) {
+            console.error('Screenshot error:', err);
+        }
+    });
 
     uiElements.slider.oninput = () => { brushRadius = mapRadius(uiElements.slider.value); };
     brushRadius = mapRadius(uiElements.slider.value);


### PR DESCRIPTION
## Summary
- capture 3D canvas screenshot on Ready button click
- append screenshot to form submission so it gets emailed
- add helper to convert data URL to blob
- style Ready button after screenshot capture
- preserve drawing buffer so screenshot isn't blank

## Testing
- `npm test` *(fails: Missing script)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c531ebc44832b97b5507ed34fa820